### PR TITLE
CI checks out the repo using a GH app token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -30,12 +31,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - 
+    -
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.CODEGEN_APP_ID }}
+        private-key: ${{ secrets.CODEGEN_APP_KEY }}
+    -
       name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - 
+        token: ${{ steps.app-token.outputs.token }}
+    -
       name: Read Configuration
       uses: hashicorp/vault-action@v3
       id: vault
@@ -47,12 +55,12 @@ jobs:
           kv/data/github    "READ_WRITE_TOKEN"  | GH_TOKEN;
           kv/data/buf.build "ASERTO_BUF_USER"   | BUF_USER;
           kv/data/buf.build "ASERTO_BUF_TOKEN"  | BUF_TOKEN;
-    - 
+    -
       name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GO_VERSION }}
-    - 
+    -
       name: Setup buf
       uses: bufbuild/buf-setup-action@v1
       with:
@@ -60,16 +68,16 @@ jobs:
         github_token: ${{ github.token }}
         buf_user: ${{ steps.vault.outputs.BUF_USER }}
         buf_api_token: ${{ steps.vault.outputs.BUF_TOKEN}}
-    - 
+    -
       name: Delete generated code
       run: |
         rm -rf ./aserto
-    - 
+    -
       name: Get latest version tag from Buf Registry
       id: buf-latest
       run: |
         echo "VERSION=$(buf beta registry label list ${BUF_REPO} --format json --reverse | jq -r '.results[0].name')" >> "$GITHUB_OUTPUT"
-    - 
+    -
       name: Buf Generate
       run: |
         echo "${{ env.BUF_REPO }}:${{ steps.buf-latest.outputs.VERSION }}"
@@ -89,7 +97,7 @@ jobs:
       name: Test
       run: |
         gotestsum --format short-verbose -- -count=1 -parallel=1 -v -timeout=240s -coverprofile=cover.out -coverpkg=./... ./...
-    - 
+    -
       name: Commit changes
       if: github.event_name == 'workflow_dispatch'
       uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
The app is allowed to bypass branch protection rules in the repo. This setup ensures that branch protection is enforced for human contributors, but the automated workflow can generate code and commit it to main.